### PR TITLE
Add support for adding private jinja2 board description file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG extra_packages=""
 RUN apt -q update && DEBIAN_FRONTEND=noninteractive apt-get -q -y upgrade
 RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install ${extra_packages}
 
+COPY ./overlays/etc/lava-server/dispatcher-config/device-types/* /etc/lava-server/dispatcher-config/device-types/
 COPY ./scripts/add_admin.sh /root/add_admin.sh
 COPY ./scripts/populate_devices.sh /root/populate_devices.sh
 COPY ./scripts/entrypoint_custom.sh /root/entrypoint_custom.sh

--- a/overlays/etc/lava-server/dispatcher-config/device-types/.README
+++ b/overlays/etc/lava-server/dispatcher-config/device-types/.README
@@ -1,0 +1,1 @@
+Add jinja2 board description file here.


### PR DESCRIPTION
For playing there is no way how to add new description for new boards.
Create device-types folder and copy content to container.

Signed-off-by: Michal Simek <monstr@monstr.eu>